### PR TITLE
Rename GROK to GROQ

### DIFF
--- a/backend/.env.prod.template
+++ b/backend/.env.prod.template
@@ -10,8 +10,8 @@ OPENAI_API_KEY=<your_key_here>
 OPENAI_MODEL=<your_model_here>
 GEMINI_API_KEY=<your_key_here>
 GEMINI_MODEL=<your_model_here>
-GROK_API_KEY=<your_key_here>
-GROK_MODEL=<your_model_here>
+GROQ_API_KEY=<your_key_here>
+GROQ_MODEL=<your_model_here>
 
 # Langsmith configuration
 export LANGSMITH_TRACING=true

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -10,8 +10,8 @@ OPENAI_API_KEY=<your_key_here>
 OPENAI_MODEL=<your_model_here>
 GEMINI_API_KEY=<your_key_here>
 GEMINI_MODEL=<your_model_here>
-GROK_API_KEY=<your_key_here>
-GROK_MODEL=<your_model_here>
+GROQ_API_KEY=<your_key_here>
+GROQ_MODEL=<your_model_here>
 
 # Langsmith configuration
 export LANGSMITH_TRACING=true

--- a/backend/AI_CONFIGURATION.md
+++ b/backend/AI_CONFIGURATION.md
@@ -12,14 +12,14 @@ The evaluation endpoint now supports specifying custom AI providers, models, and
 
 The `EvaluationRequest` schema now includes three optional fields:
 
-- `ai_provider`: AI provider to use (openai, gemini, grok)
+- `ai_provider`: AI provider to use (openai, gemini, groq)
 - `ai_model`: Specific model for the selected provider
 - `ai_api_key`: API key for the provider
 
 ### Validation Rules
 
 - If any AI configuration field is provided, all three must be provided
-- `ai_provider` must be one of: "openai", "gemini", "grok"
+- `ai_provider` must be one of: "openai", "gemini", "groq"
 - `ai_model` and `ai_api_key` are required when `ai_provider` is specified
 
 ### Header Support
@@ -90,8 +90,8 @@ curl -X POST "http://localhost:8000/api/v1/evaluations" \
 - Models: gemini-1.5-pro, gemini-2.5-flash, etc.
 - API Key Format: `AIza...`
 
-### Grok
-- Models: grok-beta, etc.
+### Groq
+- Models: groq-beta, etc.
 - API Key Format: varies by provider
 
 ## Error Handling

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -16,7 +16,7 @@ class AIProvider(str, Enum):
     """Supported AI providers."""
     OPENAI = "openai"
     GEMINI = "gemini"
-    GROK = "grok"
+    GROQ = "groq"
 
 
 class Settings(BaseSettings):
@@ -59,8 +59,8 @@ class Settings(BaseSettings):
     OPENAI_MODEL: str = ""
     GEMINI_API_KEY: str = ""
     GEMINI_MODEL: str = ""
-    GROK_API_KEY: str = ""
-    GROK_MODEL: str = ""
+    GROQ_API_KEY: str = ""
+    GROQ_MODEL: str = ""
     EMBEDDING_MODEL: str = "models/gemini-embedding-001"
     
 
@@ -87,7 +87,7 @@ class Settings(BaseSettings):
         extra="ignore"  # Ignore extra environment variables
     )
 
-    @field_validator('OPENAI_API_KEY', 'GEMINI_API_KEY', 'GROK_API_KEY', mode='before')
+    @field_validator('OPENAI_API_KEY', 'GEMINI_API_KEY', 'GROQ_API_KEY', mode='before')
     @classmethod
     def validate_api_keys(cls, v: str, info) -> str:
         """Validate that API keys are provided."""
@@ -95,7 +95,7 @@ class Settings(BaseSettings):
             raise ValueError(f"{info.field_name} must be provided in .env file")
         return v
     
-    @field_validator('OPENAI_MODEL', 'GEMINI_MODEL', 'GROK_MODEL', mode='before')
+    @field_validator('OPENAI_MODEL', 'GEMINI_MODEL', 'GROQ_MODEL', mode='before')
     @classmethod
     def validate_models(cls, v: str, info) -> str:
         """Validate that models are provided."""
@@ -114,8 +114,8 @@ def get_api_key(provider: AIProvider) -> str:
         return settings.OPENAI_API_KEY
     elif provider == AIProvider.GEMINI:
         return settings.GEMINI_API_KEY
-    elif provider == AIProvider.GROK:
-        return settings.GROK_API_KEY
+    elif provider == AIProvider.GROQ:
+        return settings.GROQ_API_KEY
     else:
         raise ValueError(f"Unknown provider: {provider}")
     
@@ -126,8 +126,8 @@ def get_model(provider: AIProvider) -> str:
         return settings.OPENAI_MODEL
     elif provider == AIProvider.GEMINI:
         return settings.GEMINI_MODEL
-    elif provider == AIProvider.GROK:
-        return settings.GROK_MODEL
+    elif provider == AIProvider.GROQ:
+        return settings.GROQ_MODEL
     else:
         raise ValueError(f"Unknown provider: {provider}")
     

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -11,5 +11,5 @@ env =
     OPENAI_MODEL=chatgpt
     GEMINI_API_KEY=geminiabcdefghijklmnopqrstuvwxyz
     GEMINI_MODEL=gemini
-    GROK_API_KEY=grokabcdefghijklmnopqrstuvwxyz
-    GROK_MODEL=grok
+    GROQ_API_KEY=groqabcdefghijklmnopqrstuvwxyz
+    GROQ_MODEL=groq

--- a/backend/routers/evaluations.py
+++ b/backend/routers/evaluations.py
@@ -207,15 +207,15 @@ def get_evaluation(
                                 "ai_model": "gemini-1.5-pro"
                             }
                         },
-                        "grok_evaluation": {
-                            "summary": "Evaluation with Grok configuration",
-                            "description": "Create an evaluation using Grok (API key via X-API-Key header)",
+                        "groq_evaluation": {
+                            "summary": "Evaluation with Groq configuration",
+                            "description": "Create an evaluation using Groq (API key via X-API-Key header)",
                             "value": {
                                 "repo_url": "https://github.com/student/backend-project",
                                 "rubric_id": 1,
                                 "briefing_path": "<FILE_UPLOAD_PATH>/project-briefing.pdf",
-                                "ai_provider": "grok",
-                                "ai_model": "grok-beta"
+                                "ai_provider": "groq",
+                                "ai_model": "groq-beta"
                             }
                         }
                     }

--- a/backend/schemas/evaluation.py
+++ b/backend/schemas/evaluation.py
@@ -24,7 +24,7 @@ class EvaluationRequest(BaseModel):
         repo_url: URL of the GitHub repository to evaluate
         rubric_id: ID of the rubric to use for evaluation
         briefing_path: Path to the briefing PDF file
-        ai_provider: AI provider to use (openai, gemini, grok) - optional
+        ai_provider: AI provider to use (openai, gemini, groq) - optional
         ai_model: Specific model for the provider - optional
         ai_api_key: API key for the provider - optional
     """
@@ -32,7 +32,7 @@ class EvaluationRequest(BaseModel):
     repo_url: str
     rubric_id: int
     briefing_path: str
-    ai_provider: Optional[str] = Field(None, description="AI provider: openai, gemini, or grok")
+    ai_provider: Optional[str] = Field(None, description="AI provider: openai, gemini, or groq")
     ai_model: Optional[str] = Field(None, description="Specific model for the selected provider")
     ai_api_key: Optional[str] = Field(None, description="API key for the selected provider")
 
@@ -41,7 +41,7 @@ class EvaluationRequest(BaseModel):
     def validate_ai_provider(cls, v):
         """Validate that ai_provider is one of the supported providers."""
         if v is not None:
-            valid_providers = ['openai', 'gemini', 'grok']
+            valid_providers = ['openai', 'gemini', 'groq']
             if v not in valid_providers:
                 raise ValueError(f"ai_provider must be one of: {', '.join(valid_providers)}")
         return v

--- a/backend/services/ai_client.py
+++ b/backend/services/ai_client.py
@@ -19,18 +19,18 @@ class AIProvider(str, Enum):
     Attributes:
         OPENAI: OpenAI API provider
         GEMINI: Google Gemini API provider  
-        GROK: Grok API provider
+        GROQ: Groq API provider
     """
     OPENAI = "openai"
     GEMINI = "gemini"
-    GROK = "grok"
+    GROQ = "groq"
 
 
 class AIClient:
     """AI client for interacting with different AI service providers.
     
     This class provides a unified interface for connecting to and communicating
-    with various AI providers (OpenAI, Gemini, Grok) for code evaluation tasks.
+    with various AI providers (OpenAI, Gemini, Groq) for code evaluation tasks.
     It handles authentication, client initialization, and chat interactions.
     
     Attributes:
@@ -106,9 +106,9 @@ class AIClient:
                     error=str(e)
                 ))
 
-        if self.provider == AIProvider.GROK:
+        if self.provider == AIProvider.GROQ:
             try:
-                api_key = self.api_key or get_api_key(AIProvider.GROK)
+                api_key = self.api_key or get_api_key(AIProvider.GROQ)
                 return Groq(api_key=api_key)
             except Exception as e:
                 raise ValueError(Messages.AIProvider.INITIALIZATION_FAILED.format(
@@ -168,7 +168,7 @@ class AIClient:
             )
             return response.text
 
-        if self.provider == AIProvider.GROK:
+        if self.provider == AIProvider.GROQ:
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=[

--- a/backend/services/ai_evaluation_engine.py
+++ b/backend/services/ai_evaluation_engine.py
@@ -455,7 +455,7 @@ def run_evaluation_task(
     Args:
         evaluation_id: The ID of the evaluation to process
         db_url: Database URL for creating a new session
-        ai_provider: AI provider to use (openai, gemini, grok) - optional
+        ai_provider: AI provider to use (openai, gemini, groq) - optional
         ai_model: Specific model for the provider - optional
         ai_api_key: API key for the provider - optional
     """

--- a/backend/services/evaluation_service_api.py
+++ b/backend/services/evaluation_service_api.py
@@ -19,7 +19,7 @@ from services.ai_evaluation_engine import AIEvaluationEngine, run_evaluation_tas
 from core.logging_config import logger
 from core.messages import Messages
 from core.database import SessionLocal
-from core.settings import settings
+from core.settings import AIProvider, settings
 
 
 class EvaluationServiceAPI:
@@ -242,7 +242,7 @@ def run_evaluation_task(
     Args:
         evaluation_id: The ID of the evaluation to process
         db_url: Database URL for creating a new session
-        ai_provider: AI provider to use (openai, gemini, grok) - optional
+        ai_provider: AI provider to use (openai, gemini, groq) - optional
         ai_model: Specific model for the provider - optional
         ai_api_key: API key for the provider - optional
     """
@@ -263,7 +263,9 @@ def run_evaluation_task(
         logger.debug(f"Evaluation {evaluation_id} status updated to '{settings.EVALUATION_STATUS_PROCESSING}'")
 
         # 2. Initialize AI evaluation engine
-        ai_engine = AIEvaluationEngine()
+        if not ai_provider:
+            ai_provider = AIProvider.GEMINI
+        ai_engine = AIEvaluationEngine(provider = ai_provider, model = ai_model, api_key = ai_api_key)
 
         # 3. Parse briefing chunks from snapshot
         try:

--- a/backend/tests/services/test_ai_evaluation_engine.py
+++ b/backend/tests/services/test_ai_evaluation_engine.py
@@ -303,12 +303,12 @@ class TestRunEvaluationTask:
         assert mock_evaluation.status == settings.EVALUATION_STATUS_FAILED
         assert "Evaluation failed: Failed to parse AI response: Expecting value: line 1 column 1 (char 0)" in mock_evaluation.ai_summary
 
-    @pytest.mark.parametrize("provider", [AIProvider.OPENAI, AIProvider.GEMINI, AIProvider.GROK])
-    # @pytest.mark.parametrize("model", ['chatgpt', 'gemini', 'grok'])
+    @pytest.mark.parametrize("provider", [AIProvider.OPENAI, AIProvider.GEMINI, AIProvider.GROQ])
+    # @pytest.mark.parametrize("model", ['chatgpt', 'gemini', 'groq'])
     # @pytest.mark.parametrize("api_key", [
     #     'openaiabcdefghijklmnopqrstuvwxyz', 
     #     'geminiabcdefghijklmnopqrstuvwxyz', 
-    #     'grokabcdefghijklmnopqrstuvwxyz'
+    #     'groqabcdefghijklmnopqrstuvwxyz'
     # ])
     @patch('services.ai_evaluation_engine.AIClient')
     def test_ai_engine_initialization_with_providers(self, mock_ai_client, provider):
@@ -318,8 +318,8 @@ class TestRunEvaluationTask:
             mock_ai_client.assert_called_with(provider=provider, model='chatgpt', api_key='openaiabcdefghijklmnopqrstuvwxyz')
         elif provider == AIProvider.GEMINI:
             mock_ai_client.assert_called_with(provider=provider, model='gemini', api_key='geminiabcdefghijklmnopqrstuvwxyz')
-        elif provider == AIProvider.GROK:
-            mock_ai_client.assert_called_with(provider=provider, model='grok', api_key='grokabcdefghijklmnopqrstuvwxyz')
+        elif provider == AIProvider.GROQ:
+            mock_ai_client.assert_called_with(provider=provider, model='groq', api_key='groqabcdefghijklmnopqrstuvwxyz')
         
 
     @patch('services.ai_evaluation_engine.SessionLocal')

--- a/backend/tests/services/test_context_engine.py
+++ b/backend/tests/services/test_context_engine.py
@@ -70,8 +70,8 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("OPENAI_MODEL", "gpt-4")
     monkeypatch.setenv("GEMINI_API_KEY", "fake-gemini-key")
     monkeypatch.setenv("GEMINI_MODEL", "gemini-pro")
-    monkeypatch.setenv("GROK_API_KEY", "fake-grok-key")
-    monkeypatch.setenv("GROK_MODEL", "grok-1")
+    monkeypatch.setenv("GROQ_API_KEY", "fake-groq-key")
+    monkeypatch.setenv("GROQ_MODEL", "groq-1")
     monkeypatch.setenv("EMBEDDING_MODEL", "text-embedding-3-small")
     # Force Settings to re-read from patched env
     import importlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,5 @@ env =
     OPENAI_MODEL=chatgpt
     GEMINI_API_KEY=geminiabcdefghijklmnopqrstuvwxyz
     GEMINI_MODEL=gemini
-    GROK_API_KEY=grokabcdefghijklmnopqrstuvwxyz
-    GROK_MODEL=grok
+    GROQ_API_KEY=groqabcdefghijklmnopqrstuvwxyz
+    GROQ_MODEL=groq


### PR DESCRIPTION
fix: rename all references from Grok to Groq

Update AI provider references from Grok to Groq across the entire codebase to align with the correct Groq API service name.

Changes include:
- AI provider enum values in services/ai_client.py
- Configuration settings in core/settings.py
- Environment templates and documentation
- Test files and API schemas
- Router endpoints and response schemas

Closes #102