### PR TITLE
chore: remove unused imports in backend

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -25,7 +25,7 @@ Database: PostgreSQL or SQLite (via SQLAlchemy)
 """
 
 import datetime
-from sqlalchemy import Column, Integer, String, Text, Float, ForeignKey, DateTime, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Text, Float, ForeignKey, DateTime
 from sqlalchemy.orm import relationship, declarative_base
 
 Base = declarative_base()

--- a/backend/routers/evaluations.py
+++ b/backend/routers/evaluations.py
@@ -6,7 +6,7 @@ using dependency injection for both database sessions and service instances.
 """
 
 from typing import List
-from fastapi import APIRouter, Depends, status, BackgroundTasks, Header, HTTPException
+from fastapi import APIRouter, Depends, status, BackgroundTasks, Header
 
 from core.database import get_db, SQLALCHEMY_DATABASE_URL
 from core.settings import settings

--- a/backend/routers/rubrics.py
+++ b/backend/routers/rubrics.py
@@ -17,7 +17,6 @@ from schemas.rubric import (
     RubricResponseWithCriteria,
     RubricRequest,
     RubricUpdateRequest,
-    CriterionResponse,
     CriterionResponseWithLevels,
     CriterionRequest,
     CriterionUpdateRequest,

--- a/backend/services/ai_client.py
+++ b/backend/services/ai_client.py
@@ -4,7 +4,7 @@ from typing import Optional
 from openai import OpenAI
 import google.genai as genai
 from groq import Groq
-from core.settings import settings, get_api_key
+from core.settings import get_api_key
 from core.logging_config import logger
 from core.messages import Messages
 from langsmith import traceable

--- a/backend/services/ai_evaluation_engine.py
+++ b/backend/services/ai_evaluation_engine.py
@@ -11,19 +11,16 @@ This module orchestrates the complete AI evaluation workflow:
 
 import json
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import Session
-from sqlalchemy import text
 
 from core.logging_config import logger
 from core.settings import settings, get_api_key, get_model, AIProvider
 from core.database import SessionLocal
 from core.messages import Messages
-from models import Evaluation, Rubric, Criterion, Level, Finding
+from models import Rubric, Criterion, Level
 from services.git_loader import GitLoaderService
 from services.ai_client import AIClient, AIProvider
 from services.context_engine import ContextEngine
 from services.prompts import build_grading_prompt, build_summary_prompt
-import os
 
 
 class AIEvaluationEngine:

--- a/backend/services/context_engine.py
+++ b/backend/services/context_engine.py
@@ -160,7 +160,7 @@ s
         """
         Factory method to create the appropriate Embeddings instance.
         """
-        from core.settings import settings, get_api_key, AIProvider
+        from core.settings import AIProvider
         
         
 

--- a/backend/services/file_upload_service.py
+++ b/backend/services/file_upload_service.py
@@ -15,7 +15,6 @@ import os
 
 from core.settings import settings
 from core.logging_config import logger
-from core.messages import Messages
 
 
 class UploadResponse(BaseModel):

--- a/backend/services/rubric_service_api.py
+++ b/backend/services/rubric_service_api.py
@@ -15,7 +15,6 @@ from schemas.rubric import (
     RubricResponseWithCriteria,
     RubricRequest,
     RubricUpdateRequest,
-    CriterionResponse,
     CriterionResponseWithLevels,
     CriterionRequest,
     CriterionUpdateRequest,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,6 @@ and test data generation for use across all test modules.
 
 import sys
 import os
-from datetime import datetime
 
 # Add the backend directory to Python path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/backend/tests/services/test_ai_evaluation_engine.py
+++ b/backend/tests/services/test_ai_evaluation_engine.py
@@ -6,19 +6,14 @@ covering all evaluation operations and error handling scenarios.
 """
 
 import pytest
-import json
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from sqlalchemy.orm import Session
 
 from services.ai_evaluation_engine import AIEvaluationEngine
 from services.evaluation_service_api import run_evaluation_task
 from services.ai_client import AIProvider
-from models import Evaluation, Rubric, Criterion, Level, Finding
+from models import Evaluation, Finding
 from core.settings import settings
-from core.messages import Messages
-from core.database import SessionLocal
-from schemas.response import APIResponse
-from schemas.evaluation import EvaluationResponse, EvaluationResponseWithFindings, FindingResponse
 
 
 class TestAIEvaluationEngine:

--- a/backend/tests/services/test_context_engine.py
+++ b/backend/tests/services/test_context_engine.py
@@ -5,7 +5,7 @@ Uses FakeEmbeddings from langchain so tests run without a real API key.
 """
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import FakeEmbeddings

--- a/backend/tests/services/test_evaluation_service_api.py
+++ b/backend/tests/services/test_evaluation_service_api.py
@@ -4,9 +4,6 @@ Unit tests for EvaluationServiceAPI.
 This module contains comprehensive tests for the EvaluationServiceAPI class,
 covering all CRUD operations and error handling scenarios.
 """
-
-import pytest
-import json
 from unittest.mock import MagicMock, patch
 from sqlalchemy.orm import Session
 from fastapi import BackgroundTasks

--- a/backend/tests/services/test_pdf_processor.py
+++ b/backend/tests/services/test_pdf_processor.py
@@ -3,12 +3,7 @@ Tests unitarios para BriefingProcessor.
 
 Verifica que process() devuelve objetos Document de langchain con metadatos correctos.
 """
-
-import os
-import tempfile
-
 import pytest
-from unittest.mock import patch, MagicMock
 
 from langchain_core.documents import Document
 

--- a/backend/tests/services/test_rubric_service_api.py
+++ b/backend/tests/services/test_rubric_service_api.py
@@ -4,9 +4,7 @@ Unit tests for RubricServiceAPI.
 This module contains comprehensive tests for the RubricServiceAPI class,
 covering all CRUD operations and error handling scenarios.
 """
-
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from sqlalchemy.orm import Session
 
 from services.rubric_service_api import RubricServiceAPI
@@ -443,7 +441,7 @@ class TestRubricServiceAPIDelete:
         self, db_session: Session, rubric_with_criteria, rubric_service: RubricServiceAPI
     ):
         """Test delete cascades to associated criteria and levels."""
-        from models import Criterion, Level
+        from models import Criterion
 
         rubric_id = rubric_with_criteria.id
         criterion_ids = [c.id for c in rubric_with_criteria.criteria]


### PR DESCRIPTION
Remove unused imports across backend modules:
- models.py
- routers (evaluations, rubrics)
- services (ai_client, ai_evaluation_engine, context_engine, file_upload_service, rubric_service_api)
- tests (conftest, ai_evaluation_engine, context_engine, evaluation_service_api, pdf_processor, rubric_service_api)